### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,19 +6,19 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-SHTSensorType   KEYWORD1
-SHTAccuracy     KEYWORD1
-SHTSensor       KEYWORD1
+SHTSensorType	KEYWORD1
+SHTAccuracy	KEYWORD1
+SHTSensor	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-init            KEYWORD2
-readSample      KEYWORD2
-getHumidity     KEYWORD2
-getTemperature  KEYWORD2
-setAccuracy     KEYWORD2
+init	KEYWORD2
+readSample	KEYWORD2
+getHumidity	KEYWORD2
+getTemperature	KEYWORD2
+setAccuracy	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE currently requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords