### PR TITLE
Fix compiler warning and init() behaviour

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -260,7 +260,7 @@ bool SHTSensor::init()
            i < sizeof(AUTO_DETECT_SENSORS) / sizeof(AUTO_DETECT_SENSORS[0]);
            ++i) {
         mSensorType = AUTO_DETECT_SENSORS[i];
-        if (init() && readSample()) {
+        if (init()) {
           detected = true;
           break;
         }

--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -271,7 +271,10 @@ bool SHTSensor::init()
       break;
     }
   }
-  return (mSensor != NULL);
+
+  // to finish the initialization, attempt to read to make sure the communication works
+  // Note: readSample() will check for a NULL mSensor in case auto detect failed
+  return readSample();
 }
 
 bool SHTSensor::readSample()

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -166,7 +166,7 @@ public:
    * Set the sensor accuracy.
    * Returns false if the sensor does not support changing the accuracy
    */
-  virtual bool setAccuracy(__attribute__((unused)) SHTSensor::SHTAccuracy newAccuracy) {
+  virtual bool setAccuracy(SHTSensor::SHTAccuracy /* newAccuracy */) {
     return false;
   }
 

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -101,9 +101,18 @@ public:
   }
 
   /**
-   * Initialize the sensor driver
+   * Initialize the sensor driver, and probe for the sensor on the bus
+   *
+   * If SHTSensor() was created with an empty constructor or with 'sensorType'
+   * AUTO_DETECT, init() will also try to automatically detect a sensor.
+   * Auto detection will stop as soon as the first sensor was found; if you have
+   * multiple sensor types on the bus, use the 'sensorType' argument of the
+   * constructor to control which sensor type will be instantiated.
+   *
    * To read out the sensor use readSample(), followed by getTemperature() and
    * getHumidity() to retrieve the values from the sample
+   *
+   * Returns true if communication with a sensor on the bus was successful, false otherwise
    */
   bool init();
 

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -157,7 +157,7 @@ public:
    * Set the sensor accuracy.
    * Returns false if the sensor does not support changing the accuracy
    */
-  virtual bool setAccuracy(SHTSensor::SHTAccuracy newAccuracy) {
+  virtual bool setAccuracy(__attribute__((unused)) SHTSensor::SHTAccuracy newAccuracy) {
     return false;
   }
 


### PR DESCRIPTION
Two bugfixes reported in ticket #16:
- unused variable marked as such to avoid compiler warning
- init() was updated to behave the same way whether the user called with in auto-detect mode, or with a fixed sensor type: previously, only the auto-detect case would also attempt to read from the sensor, now both code paths will do so

