### PR TITLE
Fix issue #10

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -67,7 +67,7 @@ bool SHTI2cSensor::readFromI2c(uint8_t i2cAddress,
     }
   }
 
-  if (Wire.endTransmission(false) != 0) {
+  if (Wire.endTransmission() != 0) {
     return false;
   }
 


### PR DESCRIPTION
Issue #10 reports failures due to the sht driver holding the bus after sending the measurement command. This commit removes this behavior and uses the default for endTransmission() (which is no argument, defaulting to true = release bus after transmission)