### PR TITLE
Supported custom I2C + minor changes

### DIFF
--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -59,7 +59,8 @@ public:
     SHTC3,
     SHTW1,
     SHTW2,
-    SHT4X
+    SHT4X,
+    SHT85 = SHT3X
   };
 
   /**
@@ -224,7 +225,7 @@ public:
                TwoWire & wire = Wire)
       : mI2cAddress(i2cAddress), mI2cCommand(i2cCommand), mDuration(duration),
         mA(a), mB(b), mC(c), mX(x), mY(y), mZ(z), mCmd_Size(cmd_Size),
-        mWire(wire)
+        _wire(wire)
   {
   }
 
@@ -244,7 +245,7 @@ public:
   float mY;
   float mZ;
   uint8_t mCmd_Size;
-  TwoWire & mWire;
+  TwoWire & _wire;
 
 private:
   static uint8_t crc8(const uint8_t *data, uint8_t len);

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -30,6 +30,7 @@
 #define SHTSENSOR_H
 
 #include <inttypes.h>
+#include <Wire.h>
 
 // Forward declaration
 class SHTSensorDriver;
@@ -116,7 +117,7 @@ public:
    *
    * Returns true if communication with a sensor on the bus was successful, false otherwise
    */
-  bool init();
+  bool init(TwoWire & wire = Wire);
 
   /**
    * Read new values from the sensor
@@ -153,7 +154,7 @@ public:
 private:
   void cleanup();
 
-  
+
   SHTSensorDriver *mSensor;
   float mTemperature;
   float mHumidity;
@@ -201,7 +202,7 @@ public:
 class SHTI2cSensor : public SHTSensorDriver {
 public:
   /** Size of i2c commands to send */
-  
+
 
   /** Size of i2c replies to expect */
   static const uint8_t EXPECTED_DATA_SIZE;
@@ -219,9 +220,11 @@ public:
    */
   SHTI2cSensor(uint8_t i2cAddress, uint16_t i2cCommand, uint8_t duration,
                float a, float b, float c,
-               float x, float y, float z, uint8_t cmd_Size)
+               float x, float y, float z, uint8_t cmd_Size,
+               TwoWire & wire = Wire)
       : mI2cAddress(i2cAddress), mI2cCommand(i2cCommand), mDuration(duration),
-        mA(a), mB(b), mC(c), mX(x), mY(y), mZ(z), mCmd_Size(cmd_Size)
+        mA(a), mB(b), mC(c), mX(x), mY(y), mZ(z), mCmd_Size(cmd_Size),
+        mWire(wire)
   {
   }
 
@@ -241,10 +244,12 @@ public:
   float mY;
   float mZ;
   uint8_t mCmd_Size;
+  TwoWire & mWire;
 
 private:
   static uint8_t crc8(const uint8_t *data, uint8_t len);
-  static bool readFromI2c(uint8_t i2cAddress,
+  static bool readFromI2c(TwoWire & wire,
+                          uint8_t i2cAddress,
                           const uint8_t *i2cCommand,
                           uint8_t commandLength, uint8_t *data,
                           uint8_t dataLength, uint8_t duration);

--- a/arduino-sht.h
+++ b/arduino-sht.h
@@ -1,0 +1,6 @@
+#ifndef ARDUINO_SHT_H
+#define ARDUINO_SHT_H
+
+#include "SHTSensor.h"
+
+#endif


### PR DESCRIPTION
Hi,

this PR proposes the following improvements:

1. Added support to use a custom I2C instance. Default is to use the Wire instance.
2. Added header to support installation with arduino-cli
3. Added explicit constant for SHT85

They are all backward compatible improvements.

Regards.
