### PR TITLE
Fix auto-detect init() always using default bus

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -315,7 +315,7 @@ bool SHTSensor::init(TwoWire & wire)
            ++i) {
         mSensorType = AUTO_DETECT_SENSORS[i];
         delay(40); // TODO: this was necessary to make SHT4x autodetect work; revisit to find root cause
-        if (init()) {
+        if (init(wire)) {
           detected = true;
           break;
         }


### PR DESCRIPTION
Using SHTSensor::AUTO_DETECT on multiple buses would always cause the supplied bus to be overridden with the default Wire bus. Multiple instances of SHTSensor would then be linked to one and the same sensor, because auto detect stops at the first found sensor. That behavior is fixed by passing the `wire` variable to `init()`.