### PR TITLE
change order of auto detection

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -350,11 +350,15 @@ float SHT3xAnalogSensor::readTemperature()
 //
 
 const SHTSensor::SHTSensorType SHTSensor::AUTO_DETECT_SENSORS[] = {
+  SHT4X, // IMPORTANT: SHT4x needs to be probed before the SHT3x, since they
+         // share their I2C address, and probing for an SHT3x can cause the
+         // first reading of and SHT4x to be off.
+         // see https://github.com/Sensirion/arduino-sht/issues/27
+
   SHT2X,
   SHT3X,
   SHT3X_ALT,
-  SHTC1,
-  SHT4X
+  SHTC1
 };
 const float SHTSensor::TEMPERATURE_INVALID = NAN;
 const float SHTSensor::HUMIDITY_INVALID = NAN;


### PR DESCRIPTION
Since the SHT3x and SHT4x share addresses, there's an issue when an SHT4x is connected to the bus and we're probing for an SHT3x: The result is that the first reading of the SHT4x is off.

The other direction works (probing for a 4x when a 3x is connected), as such we're simply changing the order of detection

Fixes #27 