### PR TITLE
Fixes #36 Command buffer overflow with SHT2x 

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -179,25 +179,25 @@ public:
   bool readSample() override
   {
     uint8_t data[EXPECTED_DATA_SIZE];
-    uint8_t cmd[mCmd_Size * 2];
+    uint8_t cmd[mCmd_Size];
 
     // SHT2x sends T and RH in two separate commands (different to other sensors)
     // so we have to spit the command into two bytes and
     // have to read from I2C two times with EXPECTED_DATA_SIZE / 2
 
+    // read T from SHT2x Sensor
     // Upper byte is T for SHT2x Sensors
     cmd[0] = mI2cCommand >> 8;
-    // Lower byte is RH for SHT2x Sensors
-    cmd[1] = mI2cCommand & 0xff;
-
-    // read T from SHT2x Sensor
     if (!readFromI2c(mWire, mI2cAddress, cmd, mCmd_Size, data,
                      EXPECTED_DATA_SIZE / 2, mDuration)) {
       DEBUG_SHT("SHT2x readFromI2c(T) false\n");
       return false;
     }
+    
     // read RH from SHT2x Sensor
-    if (!readFromI2c(mWire, mI2cAddress, &cmd[1], mCmd_Size, &data[3],
+    // Lower byte is RH for SHT2x Sensors
+    cmd[0] = mI2cCommand & 0xff;
+    if (!readFromI2c(mWire, mI2cAddress, cmd, mCmd_Size, &data[3],
                      EXPECTED_DATA_SIZE / 2, mDuration)) {
       DEBUG_SHT("SHT2x readFromI2c(RH) false\n");
       return false;

--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -179,7 +179,7 @@ public:
   bool readSample() override
   {
     uint8_t data[EXPECTED_DATA_SIZE];
-    uint8_t cmd[mCmd_Size];
+    uint8_t cmd[mCmd_Size * 2];
 
     // SHT2x sends T and RH in two separate commands (different to other sensors)
     // so we have to spit the command into two bytes and


### PR DESCRIPTION
This fixes #36. Problem was a buffer overflow when splitting the T and RH commands for SHT2x.