### PR TITLE
Fix handling of sensor type

### DIFF
--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -1,6 +1,6 @@
 /*
+ *  Copyright (c) 2015-2016, 2026 Johannes Winkelmann <jw@smts.ch>
  *  Copyright (c) 2018, Sensirion AG <andreas.brauchli@sensirion.com>
- *  Copyright (c) 2015-2016, Johannes Winkelmann <jw@smts.ch>
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -163,13 +163,21 @@ public:
    */
   bool setAccuracy(SHTAccuracy newAccuracy);
 
-  SHTSensorType mSensorType;
+  /**
+   * Get the sensor type of this instance; useful in combination
+   * with auto detect
+   * Returns current sensor type
+   */
+  SHTSensorType getSensorType() const {
+    return mSensorType;
+  }
+
 
 private:
   void cleanup();
 
-
   SHTSensorDriver *mSensor;
+  SHTSensorType mSensorType;
   float mTemperature;
   float mHumidity;
 };

--- a/examples/sht-autodetect/sht-autodetect.ino
+++ b/examples/sht-autodetect/sht-autodetect.ino
@@ -6,6 +6,8 @@ SHTSensor sht;
 // To use a specific sensor instead of probing the bus use this command:
 // SHTSensor sht(SHTSensor::SHT3X);
 
+String getSensorName(SHTSensor::SHTSensorType);
+
 void setup() {
   // put your setup code here, to run once:
 
@@ -15,6 +17,7 @@ void setup() {
 
   if (sht.init()) {
       Serial.print("init(): success\n");
+      Serial.println("Sensor detected: " + getSensorName(sht.getSensorType()));
   } else {
       Serial.print("init(): failed\n");
   }
@@ -38,4 +41,29 @@ void loop() {
   }
 
   delay(1000);
+}
+
+String getSensorName(SHTSensor::SHTSensorType sensorType) {
+  switch (sensorType) {
+    case SHTSensor::SHTSensorType::SHT2X:
+      return "SHT2x";
+
+    case SHTSensor::SHTSensorType::SHT3X:
+    case SHTSensor::SHTSensorType::SHT85:
+      return "SHT3x/SHT85 (I2C address 0x44)";
+
+    case SHTSensor::SHTSensorType::SHT3X_ALT:
+      return "SHT3x (I2C address 0x44)";
+
+    case SHTSensor::SHTSensorType::SHTW1:
+    case SHTSensor::SHTSensorType::SHTW2:
+    case SHTSensor::SHTSensorType::SHTC1:
+    case SHTSensor::SHTSensorType::SHTC3:
+      return "SHTC1/SHTC3/SHTW1/SHTW2\n";
+
+    case SHTSensor::SHTSensorType::SHT4X:
+      return "SHT4x";
+  }
+
+  return "Unknown sensor type (" + String(sensorType) + "); please report on https://github.com/Sensirion/arduino-sht";
 }


### PR DESCRIPTION
In a recent change, we made `mSensorType` public. This PR reverts this, adds an accessor method `getSensorType()`, and updates the autodetect sample to show how to use this to display the name of the detected sensor.

I intentially avoided moving handling of the sensor name string to `SHTSensor`, as users may want different names, however I'm open to moving it in there as a convenience to the user.