### PR TITLE
correctly use of c++ syntax for  override and virtual and inheritance

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -256,7 +256,7 @@ public:
   {
   }
 
-  virtual bool setAccuracy(SHTSensor::SHTAccuracy newAccuracy)
+  bool setAccuracy(SHTSensor::SHTAccuracy newAccuracy) override
   {
     switch (newAccuracy) {
       case SHTSensor::SHT_ACCURACY_HIGH:
@@ -305,7 +305,7 @@ public:
   {
   }
 
-  virtual bool setAccuracy(SHTSensor::SHTAccuracy newAccuracy)
+  bool setAccuracy(SHTSensor::SHTAccuracy newAccuracy) override
   {
     switch (newAccuracy) {
       case SHTSensor::SHT_ACCURACY_HIGH:

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -250,11 +250,9 @@ public:
   {
   }
 
-  virtual ~SHTI2cSensor()
-  {
-  }
+  ~SHTI2cSensor() = default;
 
-  virtual bool readSample();
+  bool readSample() override;
 
   uint8_t mI2cAddress;
   uint16_t mI2cCommand;


### PR DESCRIPTION
# changes:
no functional changes only use modern cpp syntax for inheritance correctly.
If use the syntax correctly the compiler can support finding errors.

## Header file
- line 253 set default for virtual Constructor => better and new syntax
- line 255 set override to be able that compiler detect errors in overriding

## cpp file
- set override to explicit tell the compiler we are now overriding the SetAccuracy method.