### PR TITLE
Bugfix wen compile with setting -Wall => Update SHTSensor.h

### DIFF
--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -176,8 +176,8 @@ public:
 private:
   void cleanup();
 
-  SHTSensorDriver *mSensor;
   SHTSensorType mSensorType;
+  SHTSensorDriver *mSensor;
   float mTemperature;
   float mHumidity;
 };


### PR DESCRIPTION
- reorder of `*mSensor` and `mSensorType` definition due to compile error with -Wall

See issue #48 