### PR TITLE
Make examples work for compile in PlatformIO

### DIFF
--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -176,8 +176,8 @@ public:
 private:
   void cleanup();
 
-  SHTSensorDriver *mSensor;
   SHTSensorType mSensorType;
+  SHTSensorDriver *mSensor;
   float mTemperature;
   float mHumidity;
 };

--- a/examples/multiple-sht-sensors/multiple-sht-sensors.ino
+++ b/examples/multiple-sht-sensors/multiple-sht-sensors.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <Wire.h>
 #include "SHTSensor.h"
 

--- a/examples/sht-autodetect/sht-autodetect.ino
+++ b/examples/sht-autodetect/sht-autodetect.ino
@@ -1,3 +1,4 @@
+#include <Arduino.h>
 #include <Wire.h>
 
 #include "SHTSensor.h"
@@ -45,6 +46,9 @@ void loop() {
 
 String getSensorName(SHTSensor::SHTSensorType sensorType) {
   switch (sensorType) {
+    default:
+      return "INVALID sensor type (" + String(sensorType) + "); please report on https://github.com/Sensirion/arduino-sht";
+
     case SHTSensor::SHTSensorType::SHT2X:
       return "SHT2x";
 
@@ -64,6 +68,4 @@ String getSensorName(SHTSensor::SHTSensorType sensorType) {
     case SHTSensor::SHTSensorType::SHT4X:
       return "SHT4x";
   }
-
-  return "Unknown sensor type (" + String(sensorType) + "); please report on https://github.com/Sensirion/arduino-sht";
 }


### PR DESCRIPTION
Why these updates?

When you compile these examples with Platform IO you need explizit the Arduino heater file included.

# Changes:
- add `<Arduino.h>` for build without error
- add `default case` for switch in example to build without Warning and error