### PR TITLE
Draft: Cleanup measured values

### DIFF
--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -373,8 +373,6 @@ const SHTSensor::SHTSensorType SHTSensor::AUTO_DETECT_SENSORS[] = {
   SHT3X_ALT,
   SHTC1
 };
-const float SHTSensor::TEMPERATURE_INVALID = NAN;
-const float SHTSensor::HUMIDITY_INVALID = NAN;
 
 bool SHTSensor::init(TwoWire & wire)
 {

--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -55,9 +55,12 @@ SHTSensorDriver::~SHTSensorDriver()
 
 bool SHTSensorDriver::readSample()
 {
-  return false;
-}
+  // set to NAN in case the readout fails
+  mTemperature = NAN;
+  mHumidity = NAN;
 
+  return readSampleInternal();
+}
 
 //
 // class SHTI2cSensor
@@ -119,7 +122,7 @@ uint8_t SHTI2cSensor::crc8(const uint8_t *data, uint8_t len, uint8_t crcInit)
 }
 
 
-bool SHTI2cSensor::readSample()
+bool SHTI2cSensor::readSampleInternal()
 {
   uint8_t data[EXPECTED_DATA_SIZE];
   uint8_t cmd[mCmd_Size];
@@ -189,7 +192,7 @@ public:
   {
   }
 
-  bool readSample() override
+  bool readSampleInternal() override
   {
     uint8_t data[EXPECTED_DATA_SIZE];
     uint8_t cmd[mCmd_Size];

--- a/SHTSensor.cpp
+++ b/SHTSensor.cpp
@@ -31,6 +31,19 @@
 
 #include "SHTSensor.h"
 
+//
+// class SHTSensor
+//
+
+float SHTSensor::getHumidity() const
+{
+  return mSensor ? mSensor->getHumidity() : NAN;
+}
+
+float SHTSensor::getTemperature() const
+{
+  return mSensor ? mSensor->getTemperature() : NAN;
+}
 
 //
 // class SHTSensorDriver
@@ -419,11 +432,9 @@ bool SHTSensor::init(TwoWire & wire)
 
 bool SHTSensor::readSample()
 {
-  if (!mSensor || !mSensor->readSample())
+  if (!mSensor)
     return false;
-  mTemperature = mSensor->mTemperature;
-  mHumidity = mSensor->mHumidity;
-  return true;
+  return mSensor->readSample();
 }
 
 bool SHTSensor::setAccuracy(SHTAccuracy newAccuracy)

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -107,9 +107,7 @@ public:
    */
   SHTSensor(SHTSensorType sensorType = AUTO_DETECT)
       : mSensorType(sensorType),
-        mSensor(NULL),
-        mTemperature(SHTSensor::TEMPERATURE_INVALID),
-        mHumidity(SHTSensor::HUMIDITY_INVALID)
+        mSensor(NULL)
   {
   }
 
@@ -145,17 +143,13 @@ public:
    * Get the relative humidity in percent read from the last sample
    * Use readSample() to trigger a new sensor reading
    */
-  float getHumidity() const {
-    return mHumidity;
-  }
+  float getHumidity() const;
 
   /**
    * Get the temperature in Celsius read from the last sample
    * Use readSample() to trigger a new sensor reading
    */
-  float getTemperature() const {
-    return mTemperature;
-  }
+  float getTemperature() const;
 
   /**
    * Change the sensor accurancy, if supported by the sensor
@@ -178,8 +172,6 @@ private:
 
   SHTSensorType mSensorType;
   SHTSensorDriver *mSensor;
-  float mTemperature;
-  float mHumidity;
 };
 
 

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -89,10 +89,6 @@ public:
     SHT_ACCURACY_LOW
   };
 
-  /** Value reported by getHumidity() when the sensor is not initialized */
-  static const float HUMIDITY_INVALID;
-  /** Value reported by getTemperature() when the sensor is not initialized */
-  static const float TEMPERATURE_INVALID;
   /**
    * Auto-detectable sensor types.
    * Note that the SHTC3, SHTW1 and SHTW2 share exactly the same driver as the SHTC1

--- a/SHTSensor.h
+++ b/SHTSensor.h
@@ -186,7 +186,7 @@ public:
   }
 
   /** Returns true if the next sample was read and the values are cached */
-  virtual bool readSample();
+  bool readSample();
 
   /**
    * Get the relative humidity in percent read from the last sample
@@ -203,6 +203,9 @@ public:
   float getTemperature() const {
     return mTemperature;
   }
+
+protected:
+  virtual bool readSampleInternal() = 0;
 
   float mTemperature;
   float mHumidity;
@@ -240,8 +243,6 @@ public:
 
   ~SHTI2cSensor() = default;
 
-  bool readSample() override;
-
   uint8_t mI2cAddress;
   uint16_t mI2cCommand;
   uint8_t mDuration;
@@ -257,6 +258,8 @@ public:
 private:
 
 protected:
+   bool readSampleInternal() override;
+
   static uint8_t crc8(const uint8_t *data, uint8_t len, uint8_t crcInit = 0xff);
   static bool readFromI2c(TwoWire & wire,
                           uint8_t i2cAddress,


### PR DESCRIPTION
Set internal members for temperature and humidity to NAN before attempting to read from the I2C bus, such that I2C errors will also be apparent in the values returned by getHumidity() and getTemperature()